### PR TITLE
use assignment to copy array and dict in holder

### DIFF
--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -38,14 +38,10 @@ Holder& Holder::operator=(const Holder& other) {
                 this->holder_string = other.holder_string;
                 break;
             case ARRAY:
-                for (int i = 0; i < other.holder_array.size(); i++) {
-                    this->holder_array.push_back(other.holder_array[i]);
-                }
+                this->holder_array = other.holder_array;
                 break;
             case DICT:
-                for (auto& [key, value] : other.holder_dict) {
-                    this->holder_dict[key] = value;
-                }
+                this->holder_dict = other.holder_dict;
                 break;
         }
     }


### PR DESCRIPTION
the previous iterating approaches did not remove stale items when an object was reused
assignment provides an opportunity for the library to optimise the iteration

fixes https://github.com/kdewald/nativeble/issues/10 for me right now