### PR TITLE
Release v1.1.1

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -52,7 +52,7 @@ ConstructorInitializerAllOnOneLineOrOnePerLine: true
 ConstructorInitializerIndentWidth: 4
 ContinuationIndentWidth: 4
 Cpp11BracedListStyle: true
-DerivePointerAlignment: true
+DerivePointerAlignment: false
 DisableFormat:   false
 ExperimentalAutoDetectBinPacking: false
 FixNamespaceComments: true
@@ -93,6 +93,7 @@ PenaltyBreakString: 1000
 PenaltyExcessCharacter: 1000000
 PenaltyReturnTypeOnItsOwnLine: 200
 PointerAlignment: Left
+PointerBindsToType: true
 ReflowComments:  true
 SortIncludes:    true
 SortUsingDeclarations: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,19 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.1.1] - 2021-02-20
+### Added
+- Implemented move and copy constructors for `SimpleDBus::Message`.
+
+### Changed
+- Pointers to DBus connection and error objects within `SimpleDBus::Connection` were made private.
+- All library targets are now compiled with maximum optimization options.
+- Changed code formatting settings.
+
+### Fixed
+- `SimpleDBus::Holder` array representation would only print the last element of the array.
+- `InterfacesRemoved` signal would unnecessarily delete an object.
+
 ## [1.1.0] - 2021-02-08
 ### Added
 - BluezService can now pick a specific adapter.
@@ -26,6 +39,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Recursion deadlock when attempting to print logs. *(Thank you xloem!)*
 - Proper cleanup of internal string buffer of the logging module. *(Thank you xloem!)*
 - Holder objects not clearing their state during copy-assignment. *(Thank you xloem!)*
+
 
 ## [1.0.0] - 2020-06-19
 - First implementation!

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,8 +31,8 @@ file(GLOB_RECURSE SRC_SIMPLEDBUS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/simpledb
 add_library(simpledbus-static STATIC ${SRC_SIMPLEDBUS_FILES})
 add_library(simpledbus SHARED ${SRC_SIMPLEDBUS_FILES})
 
-target_compile_options(simpledbus-static PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic)
-target_compile_options(simpledbus PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic)
+target_compile_options(simpledbus-static PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic -O3)
+target_compile_options(simpledbus PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic -O3)
 
 target_link_libraries(simpledbus-static PUBLIC ${DBUS_LIBRARIES})
 target_link_libraries(simpledbus PUBLIC ${DBUS_LIBRARIES})
@@ -43,8 +43,8 @@ file(GLOB_RECURSE SRC_BLUEZDBUS_FILES "${CMAKE_CURRENT_SOURCE_DIR}/src/bluezdbus
 add_library(bluezdbus-static STATIC ${SRC_BLUEZDBUS_FILES})
 add_library(bluezdbus SHARED ${SRC_BLUEZDBUS_FILES})
 
-target_compile_options(bluezdbus-static PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic)
-target_compile_options(bluezdbus PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic)
+target_compile_options(bluezdbus-static PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic -O3)
+target_compile_options(bluezdbus PUBLIC -std=c++17 -fPIC -Wfatal-errors -Wpedantic -O3)
 
 target_link_libraries(bluezdbus-static PUBLIC simpledbus-static)
 target_link_libraries(bluezdbus PUBLIC simpledbus-static)

--- a/src/bluezdbus/BluezAdapter.cpp
+++ b/src/bluezdbus/BluezAdapter.cpp
@@ -70,7 +70,23 @@ bool BluezAdapter::remove_path(std::string path, SimpleDBus::Holder options) {
     int path_elements = std::count(path.begin(), path.end(), '/');
     if (path.rfind(_path, 0) == 0) {
         if (path_elements == 4) {
-            devices.erase(path);
+            // HACK: Due to the library architecture, the only way to make sure if one
+            // of the underlying objects has to be deleted is to check if the options
+            // list contains `org.bluez.Device1`, `org.freedesktop.DBus.Introspectable`,
+            // or `org.freedesktop.DBus.Properties`.
+            // A BluezDevice might also extend from `org.bluez.Battery1`, for example.
+            // Eventually this structure will have to be revisited.
+            std::vector<std::string> interface_list;
+            for (auto& option : options.get_array()) {
+                interface_list.push_back(option.get_string());
+            }
+            bool must_erase = std::any_of(interface_list.begin(), interface_list.end(), [](const std::string& str) {
+                return str == "org.freedesktop.DBus.Properties" || str == "org.freedesktop.DBus.Introspectable" ||
+                       str == "org.bluez.Device1";
+            });
+            if(must_erase) {
+                devices.erase(path);
+            }
             return true;
         } else {
             // Propagate the paths downwards until someone claims it.

--- a/src/bluezdbus/BluezAdapter.cpp
+++ b/src/bluezdbus/BluezAdapter.cpp
@@ -84,7 +84,7 @@ bool BluezAdapter::remove_path(std::string path, SimpleDBus::Holder options) {
                 return str == "org.freedesktop.DBus.Properties" || str == "org.freedesktop.DBus.Introspectable" ||
                        str == "org.bluez.Device1";
             });
-            if(must_erase) {
+            if (must_erase) {
                 devices.erase(path);
             }
             return true;

--- a/src/bluezdbus/BluezAgent.cpp
+++ b/src/bluezdbus/BluezAgent.cpp
@@ -1,10 +1,8 @@
 #include "BluezAgent.h"
 
-BluezAgent::BluezAgent(std::string path, SimpleDBus::Holder options) : _path(path) {
-}
+BluezAgent::BluezAgent(std::string path, SimpleDBus::Holder options) : _path(path) {}
 
-BluezAgent::~BluezAgent() {
-}
+BluezAgent::~BluezAgent() {}
 
 bool BluezAgent::process_received_signal(SimpleDBus::Message& message) {
     if (message.get_path() == _path) {

--- a/src/bluezdbus/BluezDevice.cpp
+++ b/src/bluezdbus/BluezDevice.cpp
@@ -6,7 +6,6 @@
 
 BluezDevice::BluezDevice(SimpleDBus::Connection* conn, std::string path, SimpleDBus::Holder managed_interfaces)
     : _conn(conn), _path(path), Device1{conn, path}, Properties{conn, "org.bluez", path} {
-
     Properties::PropertiesChanged = [&](std::string interface, SimpleDBus::Holder changed_properties,
                                         SimpleDBus::Holder invalidated_properties) {
         if (interface == "org.bluez.Device1") {

--- a/src/bluezdbus/BluezGattCharacteristic.cpp
+++ b/src/bluezdbus/BluezGattCharacteristic.cpp
@@ -2,19 +2,11 @@
 
 #include "simpledbus/base/Logger.h"
 
-#include <iostream>
-
 BluezGattCharacteristic::BluezGattCharacteristic(SimpleDBus::Connection* conn, std::string path,
                                                  SimpleDBus::Holder managed_interfaces)
     : _conn(conn), _path(path), GattCharacteristic1{conn, path}, Properties{conn, "org.bluez", path} {
-    // std::cout << "Creating BluezGattCharacteristic: " << path << std::endl;
-
     Properties::PropertiesChanged = [&](std::string interface, SimpleDBus::Holder changed_properties,
                                         SimpleDBus::Holder invalidated_properties) {
-        // std::cout << "(" << _path << ") PropertiesChanged" << std::endl;
-        // std::cout << changed_properties.represent() << std::endl;
-        // std::cout << invalidated_properties.represent() << std::endl;
-
         if (interface == "org.bluez.GattCharacteristic1") {
             GattCharacteristic1::set_options(changed_properties, invalidated_properties);
         } else {
@@ -61,6 +53,7 @@ bool BluezGattCharacteristic::add_path(std::string path, SimpleDBus::Holder opti
     return false;
 }
 
-bool BluezGattCharacteristic::remove_path(std::string path, SimpleDBus::Holder options) { 
+bool BluezGattCharacteristic::remove_path(std::string path, SimpleDBus::Holder options) {
     LOG_F(DEBUG, "remove_path not implemented (%s needed to remove %s)", _path.c_str(), _path.c_str());
-    return false; }
+    return false;
+}

--- a/src/bluezdbus/BluezGattCharacteristic.cpp
+++ b/src/bluezdbus/BluezGattCharacteristic.cpp
@@ -14,7 +14,6 @@ BluezGattCharacteristic::BluezGattCharacteristic(SimpleDBus::Connection* conn, s
         // std::cout << "(" << _path << ") PropertiesChanged" << std::endl;
         // std::cout << changed_properties.represent() << std::endl;
         // std::cout << invalidated_properties.represent() << std::endl;
-        // // TODO: Handle the changed property.
 
         if (interface == "org.bluez.GattCharacteristic1") {
             GattCharacteristic1::set_options(changed_properties, invalidated_properties);
@@ -35,7 +34,7 @@ BluezGattCharacteristic::~BluezGattCharacteristic() {
 bool BluezGattCharacteristic::process_received_signal(SimpleDBus::Message& message) {
     if (message.get_path() == _path) {
         if (Properties::process_received_signal(message)) return true;
-        std::cout << message.to_string() << std::endl;
+        // TODO: Add any remaining signal receivers.
     }
     return false;
 }

--- a/src/bluezdbus/BluezGattService.cpp
+++ b/src/bluezdbus/BluezGattService.cpp
@@ -2,13 +2,9 @@
 
 #include "simpledbus/base/Logger.h"
 
-#include <iostream>
-
 BluezGattService::BluezGattService(SimpleDBus::Connection* conn, std::string path,
                                    SimpleDBus::Holder managed_interfaces)
     : _conn(conn), _path(path), GattService1{conn, path}, Properties{conn, "org.bluez", path} {
-    // std::cout << "Creating BluezGattService: " << path << std::endl;
-
     Properties::PropertiesChanged = [&](std::string interface, SimpleDBus::Holder changed_properties,
                                         SimpleDBus::Holder invalidated_properties) {
         if (interface == "org.bluez.GattService1") {
@@ -23,9 +19,7 @@ BluezGattService::BluezGattService(SimpleDBus::Connection* conn, std::string pat
     }
 }
 
-BluezGattService::~BluezGattService() {
-    // std::cout << "Destroying BluezGattService" << std::endl;
-}
+BluezGattService::~BluezGattService() {}
 
 bool BluezGattService::process_received_signal(SimpleDBus::Message& message) {
     if (message.get_path() == _path) {

--- a/src/bluezdbus/BluezGattService.h
+++ b/src/bluezdbus/BluezGattService.h
@@ -6,8 +6,8 @@
 
 #include "BluezGattCharacteristic.h"
 
-#include <string>
 #include <memory>
+#include <string>
 
 class BluezGattService : public GattService1, public SimpleDBus::Properties {
   private:

--- a/src/bluezdbus/BluezService.cpp
+++ b/src/bluezdbus/BluezService.cpp
@@ -9,10 +9,7 @@ BluezService::BluezService() : conn(DBUS_BUS_SYSTEM), object_manager(&conn, "org
     };
 }
 
-BluezService::~BluezService() {
-    // std::cout << "Destroying BluezService" << std::endl;
-    conn.remove_match("type='signal',sender='org.bluez'");
-}
+BluezService::~BluezService() { conn.remove_match("type='signal',sender='org.bluez'"); }
 
 void BluezService::init() {
     conn.init();

--- a/src/bluezdbus/BluezService.cpp
+++ b/src/bluezdbus/BluezService.cpp
@@ -73,9 +73,25 @@ void BluezService::remove_path(std::string path, SimpleDBus::Holder options) {
     switch (path_elements) {
         case 2:
             break;
-        case 3:
-            adapters.erase(path);
+        case 3: {
+            // HACK: Due to the library architecture, the only way to make sure if one
+            // of the underlying objects has to be deleted is to check if the options
+            // list contains `org.bluez.Adapter1`, `org.freedesktop.DBus.Introspectable`,
+            // or `org.freedesktop.DBus.Properties`.
+            // Eventually this structure will have to be revisited.
+            std::vector<std::string> interface_list;
+            for (auto& option : options.get_array()) {
+                interface_list.push_back(option.get_string());
+            }
+            bool must_erase = std::any_of(interface_list.begin(), interface_list.end(), [](const std::string& str) {
+                return str == "org.freedesktop.DBus.Properties" || str == "org.freedesktop.DBus.Introspectable" ||
+                       str == "org.bluez.Adapter1";
+            });
+            if (must_erase) {
+                adapters.erase(path);
+            }
             break;
+        }
         default:
             // Propagate the paths downwards until someone claims it.
             for (auto& [adapter_path, adapter] : adapters) {

--- a/src/bluezdbus/interfaces/Adapter1.h
+++ b/src/bluezdbus/interfaces/Adapter1.h
@@ -25,11 +25,9 @@ class Adapter1 : public SimpleDBus::Interfaces::PropertyHandler {
     void StopDiscovery();
     void SetDiscoveryFilter(SimpleDBus::Holder properties);
     SimpleDBus::Holder GetDiscoveryFilters();
-    
+
     bool is_discovering();
 
     std::function<void(void)> OnDiscoveryStarted;
     std::function<void(void)> OnDiscoveryStopped;
-
-
 };

--- a/src/bluezdbus/interfaces/Device1.cpp
+++ b/src/bluezdbus/interfaces/Device1.cpp
@@ -5,15 +5,11 @@
 const std::string Device1::_interface_name = "org.bluez.Device1";
 
 Device1::Device1(SimpleDBus::Connection* conn, std::string path)
-    : _conn(conn), _path(path), _address(""), _name(""), _connected(false), _services_resolved(false) {
-    // std::cout << "Creating org.bluez.Device1: " << path << std::endl;
-}
+    : _conn(conn), _path(path), _address(""), _name(""), _connected(false), _services_resolved(false) {}
 
 Device1::~Device1() {}
 
 void Device1::add_option(std::string option_name, SimpleDBus::Holder value) {
-    // std::cout << "\t" << option_name << std::endl;
-
     if (option_name == "Address") {
         _address = value.get_string();
     } else if (option_name == "Name") {
@@ -38,6 +34,7 @@ void Device1::add_option(std::string option_name, SimpleDBus::Holder value) {
             OnServicesResolved();
         }
     }
+    // TODO: Add ManufacturerData
 }
 
 void Device1::remove_option(std::string option_name) {}

--- a/src/bluezdbus/interfaces/GattCharacteristic1.cpp
+++ b/src/bluezdbus/interfaces/GattCharacteristic1.cpp
@@ -5,8 +5,7 @@
 const std::string GattCharacteristic1::_interface_name = "org.bluez.GattCharacteristic1";
 
 GattCharacteristic1::GattCharacteristic1(SimpleDBus::Connection* conn, std::string path)
-    : _conn(conn), _path(path), _notifying(false) {
-}
+    : _conn(conn), _path(path), _notifying(false) {}
 
 GattCharacteristic1::~GattCharacteristic1() {}
 

--- a/src/bluezdbus/interfaces/GattService1.cpp
+++ b/src/bluezdbus/interfaces/GattService1.cpp
@@ -9,13 +9,11 @@ GattService1::GattService1(SimpleDBus::Connection* conn, std::string path) : _co
 GattService1::~GattService1() {}
 
 void GattService1::add_option(std::string option_name, SimpleDBus::Holder value) {
-    if(option_name == "UUID"){
+    if (option_name == "UUID") {
         _uuid = value.get_string();
     }
 }
 
 void GattService1::remove_option(std::string option_name) {}
 
-std::string GattService1::get_uuid(){
-    return _uuid;
-}
+std::string GattService1::get_uuid() { return _uuid; }

--- a/src/simpledbus/base/Connection.cpp
+++ b/src/simpledbus/base/Connection.cpp
@@ -20,45 +20,45 @@ Connection::~Connection() {
     } while (message.is_valid());
     // ---------------------------------------------------------
 
-    dbus_error_free(&err);
-    dbus_connection_unref(conn);
+    dbus_error_free(&_err);
+    dbus_connection_unref(_conn);
 }
 
 void Connection::init() {
     dbus_threads_init_default();
-    dbus_error_init(&err);
-    conn = dbus_bus_get(_dbus_bus_type, &err);
-    if (dbus_error_is_set(&err)) {
-        LOG_F(ERROR, "Failed to get the DBus bus. (%s: %s)", err.name, err.message);
-        dbus_error_free(&err);
+    dbus_error_init(&_err);
+    _conn = dbus_bus_get(_dbus_bus_type, &_err);
+    if (dbus_error_is_set(&_err)) {
+        LOG_F(ERROR, "Failed to get the DBus bus. (%s: %s)", _err.name, _err.message);
+        dbus_error_free(&_err);
     }
 }
 
 void Connection::add_match(std::string rule) {
-    dbus_bus_add_match(conn, rule.c_str(), &err);
-    dbus_connection_flush(conn);
-    if (dbus_error_is_set(&err)) {
-        LOG_F(ERROR, "Failed to add match. (%s: %s)", err.name, err.message);
-        dbus_error_free(&err);
+    dbus_bus_add_match(_conn, rule.c_str(), &_err);
+    dbus_connection_flush(_conn);
+    if (dbus_error_is_set(&_err)) {
+        LOG_F(ERROR, "Failed to add match. (%s: %s)", _err.name, _err.message);
+        dbus_error_free(&_err);
     }
 }
 
 void Connection::remove_match(std::string rule) {
-    dbus_bus_remove_match(conn, rule.c_str(), &err);
-    dbus_connection_flush(conn);
-    if (dbus_error_is_set(&err)) {
-        LOG_F(ERROR, "Failed to remove match. (%s: %s)", err.name, err.message);
-        dbus_error_free(&err);
+    dbus_bus_remove_match(_conn, rule.c_str(), &_err);
+    dbus_connection_flush(_conn);
+    if (dbus_error_is_set(&_err)) {
+        LOG_F(ERROR, "Failed to remove match. (%s: %s)", _err.name, _err.message);
+        dbus_error_free(&_err);
     }
 }
 
 void Connection::read_write() {
     // Non blocking read of the next available message
-    dbus_connection_read_write_dispatch(conn, 0);
+    dbus_connection_read_write(_conn, 0);
 }
 
 Message Connection::pop_message() {
-    DBusMessage* msg = dbus_connection_pop_message(conn);
+    DBusMessage* msg = dbus_connection_pop_message(_conn);
     if (msg == nullptr) {
         return Message();
     } else {
@@ -68,23 +68,23 @@ Message Connection::pop_message() {
 
 uint32_t Connection::send(Message& msg) {
     uint32_t msg_serial = 0;
-    bool success = dbus_connection_send(conn, msg._msg, &msg_serial);
+    bool success = dbus_connection_send(_conn, msg._msg, &msg_serial);
 
     if (!success) {
         LOG_F(ERROR, "Message send failed.");
     } else {
-        dbus_connection_flush(conn);
+        dbus_connection_flush(_conn);
     }
     return msg_serial;
 }
 
 Message Connection::send_with_reply_and_block(Message& msg) {
-    DBusMessage* msg_tmp = dbus_connection_send_with_reply_and_block(conn, msg._msg, -1, &err);
+    DBusMessage* msg_tmp = dbus_connection_send_with_reply_and_block(_conn, msg._msg, -1, &_err);
 
-    if (dbus_error_is_set(&err)) {
-        LOG_F(WARN, "Message send failed. (%s: %s)", err.name, err.message);
-        dbus_error_free(&err);
-        return Message(); // TODO: Insert error here into the message class.
+    if (dbus_error_is_set(&_err)) {
+        LOG_F(WARN, "Message send failed. (%s: %s)", _err.name, _err.message);
+        dbus_error_free(&_err);
+        return Message();
     } else {
         return Message(msg_tmp);
     }

--- a/src/simpledbus/base/Connection.h
+++ b/src/simpledbus/base/Connection.h
@@ -10,6 +10,8 @@ class Message;
 class Connection {
   private:
     ::DBusBusType _dbus_bus_type;
+    ::DBusConnection* _conn;
+    ::DBusError _err;
 
   public:
     Connection(::DBusBusType dbus_bus_type);
@@ -23,11 +25,8 @@ class Connection {
     void read_write();
     Message pop_message();
 
-    uint32_t send(Message &msg);
-    Message send_with_reply_and_block(Message &msg);
-
-    ::DBusConnection *conn;  // TODO: Make private
-    ::DBusError err;         // TODO: Make private
+    uint32_t send(Message& msg);
+    Message send_with_reply_and_block(Message& msg);
 };
 
 }  // namespace SimpleDBus

--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -1,7 +1,7 @@
 #include "Holder.h"
+#include <iomanip>
 #include <iostream>
 #include <sstream>
-#include <iomanip>
 
 #include "dbus/dbus-protocol.h"
 
@@ -116,9 +116,9 @@ std::vector<std::string> Holder::_represent_container() {
                 for (int i = 0; i < holder_array.size(); i++) {
                     // Represent each byte as a hex string
                     std::stringstream stream;
-                    stream << std::setfill ('0') << std::setw(2) << std::hex << ((int) holder_array[i].get_byte());
+                    stream << std::setfill('0') << std::setw(2) << std::hex << ((int)holder_array[i].get_byte());
                     temp_line += (stream.str() + " ");
-                    if ((i+1) % 32 == 0) {
+                    if ((i + 1) % 32 == 0) {
                         additional_lines.push_back(temp_line);
                         temp_line = "";
                     }
@@ -126,7 +126,7 @@ std::vector<std::string> Holder::_represent_container() {
                 additional_lines.push_back(temp_line);
             } else {
                 for (int i = 0; i < holder_array.size(); i++) {
-                    for(auto& line : holder_array[i]._represent_container()){
+                    for (auto& line : holder_array[i]._represent_container()) {
                         additional_lines.push_back(line);
                     }
                 }

--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -126,7 +126,9 @@ std::vector<std::string> Holder::_represent_container() {
                 additional_lines.push_back(temp_line);
             } else {
                 for (int i = 0; i < holder_array.size(); i++) {
-                    additional_lines = holder_array[i]._represent_container();
+                    for(auto& line : holder_array[i]._represent_container()){
+                        additional_lines.push_back(line);
+                    }
                 }
             }
             for (auto& line : additional_lines) {

--- a/src/simpledbus/base/Holder.h
+++ b/src/simpledbus/base/Holder.h
@@ -23,7 +23,7 @@ typedef enum {
     SIGNATURE,
     ARRAY,
     DICT,
-} HolderType; // TODO: Move into the Holder class.
+} HolderType;  // TODO: Move into the Holder class.
 
 class Holder;
 

--- a/src/simpledbus/base/Logger.cpp
+++ b/src/simpledbus/base/Logger.cpp
@@ -6,10 +6,10 @@
 
 using namespace SimpleDBus;
 
-static const char* log_level_strings[] = {"NONE",  "FATAL",   "ERROR",   "WARN",   "INFO",
+static const char* log_level_strings[] = {"NONE",  "FATAL",   "ERROR",   "WARN",    "INFO",
                                           "DEBUG", "VERBOSE", "VERBOSE", "VERBOSE", "VERBOSE"};
 
-Logger::Logger() : _log_level(LogLevel::LOG_VERBOSE_0) {}
+Logger::Logger() : _log_level(LogLevel::LOG_INFO) {}
 
 Logger::~Logger() {}
 

--- a/src/simpledbus/base/Logger.h
+++ b/src/simpledbus/base/Logger.h
@@ -25,26 +25,26 @@ class Logger {
         LOG_VERBOSE_3,  // Used for tracking the creation/destruction of BlueZ abstractions.
     } LogLevel;
 
-    static Logger *get();
+    static Logger* get();
 
-    void log(LogLevel level, const char *file, const char *function, unsigned int line, const char *format, ...);
+    void log(LogLevel level, const char* file, const char* function, unsigned int line, const char* format, ...);
     void set_level(LogLevel level);
 
   private:
     Logger();
     ~Logger();
-    Logger(Logger &other) = delete;           // Remove the copy constructor
-    void operator=(const Logger &) = delete;  // Remove the copy assignment
+    Logger(Logger& other) = delete;          // Remove the copy constructor
+    void operator=(const Logger&) = delete;  // Remove the copy assignment
 
     void print_log(std::string message);
 
     LogLevel _log_level;
     std::mutex _mutex;
 
-    static std::string string_format(const char *format, ...);
-    static std::string string_format(const char *format, va_list vlist);
-    static std::string parse_function_signature(const char *function);
-    static std::string parse_file_path(const char *file);
+    static std::string string_format(const char* format, ...);
+    static std::string string_format(const char* format, va_list vlist);
+    static std::string parse_function_signature(const char* function);
+    static std::string parse_file_path(const char* file);
 };
 
 }  // namespace SimpleDBus

--- a/src/simpledbus/base/Message.h
+++ b/src/simpledbus/base/Message.h
@@ -48,10 +48,10 @@ class Message {
   public:
     Message();
     Message(DBusMessage* msg);
-    Message(Message&& other) = delete;         // Remove the move constructor
-    Message(const Message& other) = delete;    // Remove the copy constructor
-    Message& operator=(Message&& other);       // Implement custom move assignment
-    Message& operator=(const Message& other);  // Implement custom copy assignment
+    Message(Message&& other);                  // Custom move constructor
+    Message(const Message& other);             // Custom copy constructor
+    Message& operator=(Message&& other);       // Custom move assignment
+    Message& operator=(const Message& other);  // Custom copy assignment
     ~Message();
 
     bool is_valid() const;
@@ -63,6 +63,8 @@ class Message {
     void extract_next();
     std::string to_string() const;
 
+    int32_t get_unique_id();
+    uint32_t get_serial();
     std::string get_signature();
     std::string get_interface();
     std::string get_path();

--- a/src/simpledbus/common/ObjectManager.cpp
+++ b/src/simpledbus/common/ObjectManager.cpp
@@ -2,8 +2,6 @@
 
 #include "../base/Message.h"
 
-#include <iostream>
-
 using namespace SimpleDBus;
 
 ObjectManager::ObjectManager(Connection* conn, std::string service, std::string path)

--- a/src/simpledbus/common/ObjectManager.h
+++ b/src/simpledbus/common/ObjectManager.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <string>
 #include <functional>
+#include <string>
 
 #include "../base/Connection.h"
 #include "../base/Holder.h"
@@ -14,7 +14,7 @@ class Connection;
 class ObjectManager {
   private:
     const std::string _interface;
-    
+
     std::string _path;
     std::string _service;
     Connection* _conn;
@@ -27,7 +27,6 @@ class ObjectManager {
     Holder GetManagedObjects(bool use_callbacks = false);
     std::function<void(std::string path, Holder options)> InterfacesAdded;
     std::function<void(std::string path, Holder options)> InterfacesRemoved;
-
 
     bool process_received_signal(Message& message);
 };

--- a/src/simpledbus/common/Properties.h
+++ b/src/simpledbus/common/Properties.h
@@ -1,6 +1,6 @@
 #pragma once
-#include <string>
 #include <functional>
+#include <string>
 
 #include "../base/Connection.h"
 #include "../base/Holder.h"
@@ -14,7 +14,7 @@ class Connection;
 class Properties {
   private:
     const std::string _interface;
-    
+
     std::string _path;
     std::string _service;
     Connection* _conn;
@@ -28,7 +28,7 @@ class Properties {
     Holder GetAll(std::string interface);
     void Set(std::string interface, std::string name, Holder value);
 
-    std::function<void(std::string interface, Holder changed_properties, Holder invalidated_properties)> PropertiesChanged;
+    std::function<void(std::string interface, Holder changed, Holder invalidated)> PropertiesChanged;
 
     bool process_received_signal(Message& message);
 };


### PR DESCRIPTION
## [1.1.1] - 2021-02-20
### Added
- Implemented move and copy constructors for `SimpleDBus::Message`.

### Changed
- Pointers to DBus connection and error objects within `SimpleDBus::Connection` were made private.
- All library targets are now compiled with maximum optimization options.
- Changed code formatting settings.

### Fixed
- `SimpleDBus::Holder` array representation would only print the last element of the array.
- `InterfacesRemoved` signal would unnecessarily delete an object.