### PR TITLE
Message extract error handling.

### DIFF
--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -7,7 +7,7 @@
 
 using namespace SimpleDBus;
 
-Holder::Holder() : _type(NONE) holder_boolean(false) holder_integer(0) holder_double(0) {}
+Holder::Holder() : _type(NONE), holder_boolean(false), holder_integer(0), holder_double(0) {}
 
 Holder::~Holder() {}
 

--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -7,7 +7,7 @@
 
 using namespace SimpleDBus;
 
-Holder::Holder() : _type(NONE) {}
+Holder::Holder() : _type(NONE) holder_boolean(false) holder_integer(0) holder_double(0) {}
 
 Holder::~Holder() {}
 

--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -7,46 +7,9 @@
 
 using namespace SimpleDBus;
 
-Holder::Holder() : _type(NONE), holder_boolean(false), holder_integer(0), holder_double(0) {}
+Holder::Holder() {}
 
 Holder::~Holder() {}
-
-Holder::Holder(const Holder& other) { *this = other; }
-
-Holder& Holder::operator=(const Holder& other) {
-    if (this != &other) {
-        _type = other._type;
-        switch (_type) {
-            case BOOLEAN:
-                this->holder_boolean = other.holder_boolean;
-                break;
-            case BYTE:
-            case INT16:
-            case UINT16:
-            case INT32:
-            case UINT32:
-            case INT64:
-            case UINT64:
-                this->holder_integer = other.holder_integer;
-                break;
-            case DOUBLE:
-                this->holder_double = other.holder_double;
-                break;
-            case STRING:
-            case OBJ_PATH:
-            case SIGNATURE:
-                this->holder_string = other.holder_string;
-                break;
-            case ARRAY:
-                this->holder_array = other.holder_array;
-                break;
-            case DICT:
-                this->holder_dict = other.holder_dict;
-                break;
-        }
-    }
-    return *this;
-}
 
 HolderType Holder::type() { return _type; }
 
@@ -77,14 +40,6 @@ std::string Holder::_represent_simple() {
             break;
         case UINT64:
             output << get_uint64();
-            break;
-        case DOUBLE:
-            output << get_double();
-            break;
-        case STRING:
-        case OBJ_PATH:
-        case SIGNATURE:
-            output << get_string();
             break;
     }
     return output.str();

--- a/src/simpledbus/base/Holder.cpp
+++ b/src/simpledbus/base/Holder.cpp
@@ -41,6 +41,14 @@ std::string Holder::_represent_simple() {
         case UINT64:
             output << get_uint64();
             break;
+        case DOUBLE:
+            output << get_double();
+            break;
+        case STRING:
+        case OBJ_PATH:
+        case SIGNATURE:
+            output << get_string();
+            break;
     }
     return output.str();
 }

--- a/src/simpledbus/base/Holder.h
+++ b/src/simpledbus/base/Holder.h
@@ -30,10 +30,10 @@ class Holder;
 class Holder {
   private:
     HolderType _type;
-
-    bool holder_boolean;
-    uint64_t holder_integer;
-    double holder_double;
+    // TODO: hack around pass by value design. Should be refactored.
+    bool holder_boolean = false;
+    uint64_t holder_integer = 0;
+    double holder_double = 0;
     std::string holder_string;
     std::vector<Holder> holder_array;
     std::map<std::string, Holder> holder_dict;

--- a/src/simpledbus/base/Holder.h
+++ b/src/simpledbus/base/Holder.h
@@ -31,11 +31,9 @@ class Holder {
   private:
     HolderType _type;
 
-    union {
-        bool holder_boolean;
-        uint64_t holder_integer;
-        double holder_double;
-    };
+    bool holder_boolean = false;
+    uint64_t holder_integer = 0;
+    double holder_double = 0;
     std::string holder_string;
     std::vector<Holder> holder_array;
     std::map<std::string, Holder> holder_dict;

--- a/src/simpledbus/base/Holder.h
+++ b/src/simpledbus/base/Holder.h
@@ -29,8 +29,7 @@ class Holder;
 
 class Holder {
   private:
-    HolderType _type;
-    // TODO: hack around pass by value design. Should be refactored.
+    HolderType _type = NONE;
     bool holder_boolean = false;
     uint64_t holder_integer = 0;
     double holder_double = 0;
@@ -45,8 +44,6 @@ class Holder {
   public:
     Holder();
     ~Holder();
-    Holder(const Holder& other);
-    Holder& operator=(const Holder& other);
 
     HolderType type();
     std::string represent();

--- a/src/simpledbus/base/Holder.h
+++ b/src/simpledbus/base/Holder.h
@@ -31,9 +31,9 @@ class Holder {
   private:
     HolderType _type;
 
-    bool holder_boolean = false;
-    uint64_t holder_integer = 0;
-    double holder_double = 0;
+    bool holder_boolean;
+    uint64_t holder_integer;
+    double holder_double;
     std::string holder_string;
     std::vector<Holder> holder_array;
     std::map<std::string, Holder> holder_dict;

--- a/src/simpledbus/base/Message.cpp
+++ b/src/simpledbus/base/Message.cpp
@@ -324,6 +324,10 @@ std::string Message::to_string() const {
 }
 
 Holder Message::extract() {
+    if (!is_valid()) {
+        return Holder();
+    }
+
     if (!_is_extracted) {
         if (!_iter_initialized) {
             extract_reset();


### PR DESCRIPTION
Changes:
- `Message::extract()` error checking. This exposed some problems with `Holder` which were also fixed.
- `Holder` reorganization: remove copy and assignment constructors. Initialized default values in header file.